### PR TITLE
Add Citra and Cemu Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,9 +71,10 @@ bot.on("presenceUpdate", (_, presence) => {
                     console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
                     return;
                 }
+
                 var url = `http://tag.rc24.xyz/3ds?key=${key}&game=${currGame}`;
-                console.log(url);
-                var res = await axios.get(url);
+                //console.log(url);
+                var res = await axios.get(encodeURI(url));
                 if (res.status == 200) {
                     console.log(`${presence.user.username} is now playing ${activity.state}.`);
                 } else {

--- a/index.js
+++ b/index.js
@@ -84,6 +84,26 @@ bot.on("presenceUpdate", (_, presence) => {
                 console.log("No Game detected");
             }
         }
+        if (activity.name == "Cemu") {
+            currGame = activity.state.replace("Playing", "").trim();
+            if (currGame) {
+                var key = await getKey(presence.user.id);
+                if (!key) {
+                    console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
+                    return;
+                }
+                var url = `http://localhost:3000/wiiu?key=${key}&game=${currGame}&source=Cemu`;
+                //console.log(url);
+                var res = await axios.get(encodeURI(url));
+                if (res.status == 200) {
+                    console.log(`${presence.user.username} is now playing ${activity.state}.`);
+                } else {
+                    console.log(`Request for ${presence.user.username} failed with response code ${res.status} for game ${activity.state}}.`);
+                }
+            } else {
+                console.log("No Game detected");
+            }
+        }
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -63,6 +63,26 @@ bot.on("presenceUpdate", (_, presence) => {
                 console.log("No Game ID detected");
             }
         }
+        if (activity.name == "citra") {
+            currGame = activity.state
+            if (currGame) {
+                var key = await getKey(presence.user.id);
+                if (!key) {
+                    console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
+                    return;
+                }
+                var url = `http://tag.rc24.xyz/3ds?key=${key}&game=${currGame}`;
+                console.log(url);
+                var res = await axios.get(url);
+                if (res.status == 200) {
+                    console.log(`${presence.user.username} is now playing ${activity.state}.`);
+                } else {
+                    console.log(`Request for ${presence.user.username} failed with response code ${res.status} for game ${activity.state}}.`);
+                }
+            } else {
+                console.log("No Game detected");
+            }
+        }
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -64,8 +64,9 @@ bot.on("presenceUpdate", (_, presence) => {
             }
         }
         if (activity.name == "citra") {
-            currGame = activity.state.replace(/&/g, "%26")
+            currGame = activity.state;
             if (currGame) {
+                currGame = currGame.replace(/&/g, "%26");
                 var key = await getKey(presence.user.id);
                 if (!key) {
                     console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
@@ -85,8 +86,9 @@ bot.on("presenceUpdate", (_, presence) => {
             }
         }
         if (activity.name == "Cemu") {
-            currGame = activity.state.replace("Playing", "").trim().replace(/&/g, "%26");
-            if (currGame) {
+            currGame = activity.state;
+            if ( currGame && currGame != "Idling" ) {
+                currGame = currGame.replace("Playing", "").trim().replace(/&/g, "%26");
                 var key = await getKey(presence.user.id);
                 if (!key) {
                     console.log(`${presence.user.username} does not have a registered account on RiiTag.`);

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ bot.on("presenceUpdate", (_, presence) => {
             }
         }
         if (activity.name == "citra") {
-            currGame = activity.state
+            currGame = activity.state.replace(/&/g, "%26")
             if (currGame) {
                 var key = await getKey(presence.user.id);
                 if (!key) {
@@ -85,7 +85,7 @@ bot.on("presenceUpdate", (_, presence) => {
             }
         }
         if (activity.name == "Cemu") {
-            currGame = activity.state.replace("Playing", "").trim();
+            currGame = activity.state.replace("Playing", "").trim().replace(/&/g, "%26");
             if (currGame) {
                 var key = await getKey(presence.user.id);
                 if (!key) {


### PR DESCRIPTION
Requires https://github.com/RiiConnect24/RiiTag/pull/42 (Merged)
Requires https://github.com/RiiConnect24/RiiTag/pull/45

This PR adds support for Citra, the 3DS Emulator, and Cemu, the Wii U emulator, and their relevant RPC. It will detect whenever Citra or Cemu is running a game and will pass the full game title to RiiTag which will then in turn handle anything it needs to via the /3ds or /wiiu endpoint depending.