### PR TITLE
Yuzu/Ryujinx support

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ bot.on("presenceUpdate", (_, presence) => {
         }
         if (activity.name == "Yuzu") {
             currGame = activity.state;
-            if ( currGame && curGame != "Currently not in game" ) {
+            if ( currGame && currGame != "Currently not in game" ) {
                 currGame = currGame.trim().replace(/&/g, "%26");
                 var key = await getKey(presence.user.id);
                 if (!key) {

--- a/index.js
+++ b/index.js
@@ -137,6 +137,27 @@ bot.on("presenceUpdate", (_, presence) => {
                 console.log("No Game detected");
             }
         }
+        if (activity.name == "Ryujinx") {
+            currGame = activity.state;
+            if ( currGame && currGame != "Idling" ) {
+                currGame = currGame.replace("Playing", "").trim().replace(/&/g, "%26");
+                var key = await getKey(presence.user.id);
+                if (!key) {
+                    console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
+                    return;
+                }
+                var url = `http://tag.rc24.xyz/switch?key=${key}&game=${currGame}&source=Ryujinx`;
+                //console.log(url);
+                var res = await axios.get(encodeURI(url));
+                if (res.status == 200) {
+                    console.log(`${presence.user.username} is now playing ${activity.state}.`);
+                } else {
+                    console.log(`Request for ${presence.user.username} failed with response code ${res.status} for game ${activity.state}}.`);
+                }
+            } else {
+                console.log("No Game detected");
+            }
+        }
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,27 @@ bot.on("presenceUpdate", (_, presence) => {
                 console.log("No Game detected");
             }
         }
+        if (activity.name == "Yuzu") {
+            currGame = activity.state;
+            if ( currGame && curGame != "Currently not in game" ) {
+                currGame = currGame.trim().replace(/&/g, "%26");
+                var key = await getKey(presence.user.id);
+                if (!key) {
+                    console.log(`${presence.user.username} does not have a registered account on RiiTag.`);
+                    return;
+                }
+                var url = `http://tag.rc24.xyz/switch?key=${key}&game=${currGame}&source=Yuzu`;
+                //console.log(url);
+                var res = await axios.get(encodeURI(url));
+                if (res.status == 200) {
+                    console.log(`${presence.user.username} is now playing ${activity.state}.`);
+                } else {
+                    console.log(`Request for ${presence.user.username} failed with response code ${res.status} for game ${activity.state}}.`);
+                }
+            } else {
+                console.log("No Game detected");
+            }
+        }
     });
 });
 


### PR DESCRIPTION
Originally this was just Yuzu, but I found Ryujinx to be similar.

Here is what I pulled out of RPC for Yuzu:

```
main menu:

title - yuzu
msg - currently not in game
# bot shouldn't do anything here

on breath of the wild:

title - yuzu
msg 1 - currently in game
msg 2 - game title

# the icon also seems to match, bot do stuff here
```

I realized the way of when it says "Currently in game", and has the bottom message say the game title is like Citra. Makes sense, as iirc some yuzu devs also are citra devs

For Ryujinx:
```
ryujinx notes:

Startup:
title - ryujinx
msg 1 - main menu
msg 2 - idling

When NSMBU Deluxe is playing:
title - ryujinx
msg 1 - Playing (game)...
msg 2 - the game id
```


this code could use a lot of cleanup, maybe in another PR i'll do that.